### PR TITLE
Feat: Implement IPC Signal to Server [B2]

### DIFF
--- a/BankClient/Services/BankClientService.cs
+++ b/BankClient/Services/BankClientService.cs
@@ -35,6 +35,15 @@ namespace BankClient.Services
                         stream.Write(data, 0, data.Length);
                     }
                 }
+
+                try
+                {
+                    using (var signal = EventWaitHandle.OpenExisting(AppConstants.NewDataSignalName))
+                    {
+                        signal.Set();
+                    }
+                }
+                catch (WaitHandleCannotBeOpenedException) { }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Added EventWaitHandle logic to BankClientService. calling .Set() on 'NewDataSignal' after writing to shared memory. Added try-catch block to handle WaitHandleCannotBeOpenedException if the server is offline.